### PR TITLE
API: Implement `GET|POST /cases/{id}/messages`

### DIFF
--- a/api/app.ts
+++ b/api/app.ts
@@ -34,9 +34,13 @@ app.use('/cases', requireAuth, casesRouter)
 app.use('/timelines', requireAuth, timelinesRouter)
 
 // error handler
-app.use(function (err: any, req: express.Request, res: express.Response) {
-  console.error('error caught:', err)
-  res.status(err.status).send(err)
+interface HasStatus {
+  status?: number
+}
+
+app.use(function (err: Error & HasStatus, req: express.Request, res: express.Response, next: express.NextFunction) {
+  console.error('error caught:', err, res)
+  res.status(err.status || 500).send(err)
 })
 
 module.exports = app

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1054,6 +1054,27 @@
         "vary": "~1.1.2"
       }
     },
+    "express-validator": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.2.0.tgz",
+      "integrity": "sha512-892cPistoSPzMuoG2p1W+2ZxBi0bAvPaaYgXK1E1C8/QncLo2d1HbiDDWkXUtTthjGEzEmwiELLJHu1Ez2hOEg==",
+      "requires": {
+        "lodash": "^4.17.15",
+        "validator": "^11.1.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "validator": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+          "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
+        }
+      }
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",

--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
     "debug": "~2.6.9",
     "decamelize": "^3.2.0",
     "express": "~4.16.1",
+    "express-validator": "^6.2.0",
     "http-errors": "~1.6.3",
     "jwt-simple": "^0.5.6",
     "morgan": "~1.9.1",

--- a/api/queries/timelines.ts
+++ b/api/queries/timelines.ts
@@ -1,8 +1,14 @@
 import { Request, Response, NextFunction } from 'express'
+import { Model, Op } from 'sequelize'
+
 import { Timeline } from '../models/Timeline'
+import { Message } from '../models/Message'
+
+import { IFindAll } from '../utils/types'
+
 
 // GET
-const getTimelines = async (req: Request, res: Response, next: NextFunction) => {
+export const getTimelines = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const timelines = await Timeline.findAll()
     res.status(200).json(timelines)
@@ -12,6 +18,27 @@ const getTimelines = async (req: Request, res: Response, next: NextFunction) => 
   }
 }
 
-module.exports = {
-  getTimelines,
-}
+const getTimelineItemsByCaseId = <T extends Model<T>>(MType: IFindAll<T>) => 
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { from = 0, to = Date.now(), limit = 20 } = req.query
+      const caseId = Number(req.params.caseId)
+      const items = await MType.findAll({
+        where: {
+          caseId,
+          createdAt: { [Op.between]: [ new Date(from), new Date(to) ] },
+        },
+        order: [
+          ['createdAt', 'DESC']
+        ],
+        limit,
+      })
+      res.status(200).json(items)
+    } catch (error) {
+      console.error(error)
+      const err = { status: error.status || 500, message: error }
+      next(err)
+    }
+  }
+
+export const getMessagesByCaseId = getTimelineItemsByCaseId(Message)

--- a/api/queries/timelines.ts
+++ b/api/queries/timelines.ts
@@ -4,7 +4,7 @@ import { Model, Op } from 'sequelize'
 import { Timeline } from '../models/Timeline'
 import { Message } from '../models/Message'
 
-import { IFindAll } from '../utils/types'
+import { IFindAll, ICreate } from '../utils/types'
 
 
 // GET
@@ -41,4 +41,25 @@ const getTimelineItemsByCaseId = <T extends Model<T>>(MType: IFindAll<T>) =>
     }
   }
 
+const postTimelineItemToCase = <T extends Model<T>>(MType: ICreate<T>) => 
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const caseId = Number(req.params.caseId)
+      const user: any = req.user!
+      const userId = Number(user.id)
+      const payload = req.body
+      const item = await MType.create({
+        ...payload,
+        userId,
+        caseId,
+      })
+      res.status(200).json(item)
+    } catch (error) {
+      console.error(error)
+      const err = { status: error.status || 500, message: error }
+      next(err)
+    }
+  }
+
 export const getMessagesByCaseId = getTimelineItemsByCaseId(Message)
+export const postMessageToCase = postTimelineItemToCase(Message)

--- a/api/routes/cases.ts
+++ b/api/routes/cases.ts
@@ -1,11 +1,44 @@
 import express from 'express'
-let router = express.Router()
+import { checkSchema } from 'express-validator'
+
 const dbCases = require('../queries/cases')
+import { getMessagesByCaseId }  from '../queries/timelines'
+
+import { checkValidationPassed } from '../utils/express'
+
+let router = express.Router()
 
 router.get('/', dbCases.getCases)
 router.get('/:id', dbCases.getCasesByCaseId)
 
-// TODO: add endpoints that CRUD conversations 
-// and timeline events for a given case
+// TODO: add endpoints that CRUD timeline events for a given case
+
+const checkValidTimelineQuery = checkSchema({
+  from: {
+    in: ['query'],
+    isInt: true,
+    toInt: true,
+    optional: { options: { nullable: true } },
+  },
+  to: {
+    in: ['query'],
+    isInt: true,
+    toInt: true,
+    optional: { options: { nullable: true } },
+  },
+  limit: {
+    in: ['query'],
+    isInt: { options: { max: 50 } },
+    toInt: true,
+    optional: { options: { nullable: true } },
+  },
+})
+
+router.get(
+  '/:caseId/messages',
+  checkValidTimelineQuery,
+  checkValidationPassed,
+  getMessagesByCaseId
+)
 
 export default router

--- a/api/routes/cases.ts
+++ b/api/routes/cases.ts
@@ -2,7 +2,7 @@ import express from 'express'
 import { checkSchema } from 'express-validator'
 
 const dbCases = require('../queries/cases')
-import { getMessagesByCaseId }  from '../queries/timelines'
+import { getMessagesByCaseId, postMessageToCase }  from '../queries/timelines'
 
 import { checkValidationPassed } from '../utils/express'
 
@@ -34,6 +34,7 @@ const checkValidTimelineQuery = checkSchema({
   },
 })
 
+router.post('/:caseId/messages', postMessageToCase)
 router.get(
   '/:caseId/messages',
   checkValidTimelineQuery,

--- a/api/utils/express.ts
+++ b/api/utils/express.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from 'express'
+import { validationResult } from 'express-validator'
+
+export const checkValidationPassed  = (req: Request, res: Response, next: NextFunction) => {
+  const errors = validationResult(req)
+  if (!errors.isEmpty()) {
+    return res.status(422).json({ errors: errors.array() })
+  } else {
+    return next()
+  }
+}

--- a/api/utils/types.ts
+++ b/api/utils/types.ts
@@ -1,5 +1,9 @@
-import { Model, FindOptions } from 'sequelize';
+import { Model, FindOptions, CreateOptions } from 'sequelize';
 
 export interface IFindAll<T extends Model<T>> {
   findAll(options?: FindOptions): Promise<T[]>
+}
+
+export interface ICreate<T extends Model<T>> {
+  create(values: Object, options?: CreateOptions): Promise<T>
 }

--- a/api/utils/types.ts
+++ b/api/utils/types.ts
@@ -1,4 +1,4 @@
-import { Model, FindOptions, CreateOptions } from 'sequelize';
+import { Model, FindOptions, CreateOptions } from 'sequelize'
 
 export interface IFindAll<T extends Model<T>> {
   findAll(options?: FindOptions): Promise<T[]>

--- a/api/utils/types.ts
+++ b/api/utils/types.ts
@@ -1,0 +1,5 @@
+import { Model, FindOptions } from 'sequelize';
+
+export interface IFindAll<T extends Model<T>> {
+  findAll(options?: FindOptions): Promise<T[]>
+}


### PR DESCRIPTION
- Bring in express-validator
- Declare `GET /cases/{id}/messages`, validating these query params:
  - from, to: min/max timestamp of message in epoch milliseconds
  - limit: maximum number of messages to fetch
- Create `utils/express` to hold helper express controllers, like
  checking if we passed express-validator
- Implement `getTimelineItemsByCaseId()`, taking care to make this
  generic, so that we can reuse the logic for fetching of Messages and
  Events in the timeline
- Implement `POST /cases/{id}/messages`, allowing code reuse through
  generics
- Create `utils/types` to hold the IFindAll and ICreate interfaces
- Fixup global error handling in Express

This PR counts towards #21