### PR TITLE
Move references to agency in `Case` to `User`

### DIFF
--- a/api/src/models/Case.ts
+++ b/api/src/models/Case.ts
@@ -11,12 +11,6 @@ export class Case extends Model<Case> {
   @Column
   caseDesc: string
 
-  @Column
-  assignedAgency: string
-
-  @Column
-  agencyPoc: string
-
   @CreatedAt
   @Column
   createdAt!: Date

--- a/api/src/models/User.ts
+++ b/api/src/models/User.ts
@@ -10,6 +10,9 @@ export class User extends Model<User> {
   @Column
   email: string
 
+  @Column
+  agency: string
+
   @CreatedAt
   @Column
   createdAt!: Date

--- a/api/src/queries/cases.ts
+++ b/api/src/queries/cases.ts
@@ -21,7 +21,7 @@ const getCasesByUserId = async (req: Request, res: Response, next: NextFunction)
   try {
     const cases = await Case.findAll({
       where: { userId },
-      include: [ Client ],
+      include: [ Client, User ],
     })
     res.status(200).json(cases)
   } catch (error) {
@@ -36,6 +36,7 @@ const getCasesByCaseId = async (req: Request, res: Response, next: NextFunction)
     const thisCase = await Case.findByPk(id, {
       include: [
         Client,
+        User,
         {
           model: Event,
           include: [

--- a/api/src/tests/fixtures/cases.json
+++ b/api/src/tests/fixtures/cases.json
@@ -2,8 +2,6 @@
   {
     "userId": 1,
     "caseDesc": "Single family, requires education grant for son",
-    "assignedAgency": "MOE",
-    "agencyPoc": "chewie@moe.edu.sg",
     "clientId": 1,
     "messages": 
       [
@@ -28,8 +26,6 @@
   {
     "userId": 1,
     "caseDesc": "Single family, requires HDB loan for family",
-    "assignedAgency": "HDB",
-    "agencyPoc": "ewok@hdb.edu.sg",
     "clientId": 1,
     "messages": 
       [

--- a/api/src/tests/fixtures/users.json
+++ b/api/src/tests/fixtures/users.json
@@ -1,10 +1,12 @@
 [
   {
     "name": "admin",
-    "email": "admin@opengov.com"
+    "email": "admin@opengov.com",
+    "agency": "MOE"
   },
   {
     "name": "admin2",
-    "email": "admin2@opengov.com"
+    "email": "admin2@opengov.com",
+    "agency": "HDB"
   }
 ]

--- a/api/src/tests/integration/routes/routes.test.ts
+++ b/api/src/tests/integration/routes/routes.test.ts
@@ -149,7 +149,7 @@ describe('route endpoints', () => {
           .get('/cases/1')
           .set('cookie', 'jwt=' + token)
           .expect(200)
-        expect(res.body['assignedAgency']).toBe('MOE')
+        expect(res.body['caseDesc']).toBe('Single family, requires education grant for son')
       })
 
       // GET cases/:id/messages

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -19,6 +19,7 @@
   }
 },
   "include": [
-    "**/*"
+    "**/*",
+    "src/tests/fixtures/*.json"
   ]
 }

--- a/client/src/components/CaseViewPage/index.tsx
+++ b/client/src/components/CaseViewPage/index.tsx
@@ -46,8 +46,8 @@ class CaseViewPage extends Component<Props, State> {
     let client
 
     if (this.state.case) {
-      const { id, agencyPoc, caseDesc, createdAt } = this.state.case
-      caseDetails = <li key={id}> {agencyPoc}: {caseDesc} | {createdAt}</li>
+      const { id, user, caseDesc, createdAt } = this.state.case
+      caseDetails = <li key={id}> {user.agency}: {caseDesc} | {createdAt}</li>
 
       messages = this.state.case.messages.map((x: Message, idx: number) =>
         <li key={idx}> {x.userId} @ {x.createdAt} - {x.text}</li>

--- a/client/src/components/CasesViewPage/index.tsx
+++ b/client/src/components/CasesViewPage/index.tsx
@@ -52,7 +52,7 @@ class CasesViewPage extends Component<Props, CasesViewState> {
   render () {
     let listItems = this.state.cases.map((d: Case) =>
       <li key={d.id}> {d.client.name} | {d.caseDesc} |
-        {d.assignedAgency} - {d.agencyPoc} | {d.createdAt} |
+        {d.user.agency} - {d.user.email} | {d.createdAt} |
         <button onClick={() => this.viewCase(d.id)}>View Case</button>
       </li>
     )

--- a/client/src/models/Case.ts
+++ b/client/src/models/Case.ts
@@ -4,8 +4,6 @@ import { Client } from './Client'
 import { User } from './User'
 
 export interface Case {
-  agencyPoc: string
-  assignedAgency: string
   caseDesc: string
   client: Client
   messages: Message[]

--- a/client/src/models/User.ts
+++ b/client/src/models/User.ts
@@ -1,5 +1,6 @@
 export interface User {
   name: string
+  agency: string
   email: string
   createdAt?: Date
   id?: number


### PR DESCRIPTION
- When a `case` is first created by a `user`, the `user` will be the
designated lead agency by virtue of his association to the `case`
- Add the field `agency` to the `User` model
- Update `User` and `Case` models at the client side
- Update `case` queries to include `user` details
- Update frontend to load `user` information
- Update `tsconfig` to include json files, otherwise the fixtures will
be left out in `dist/` and `seed-db` will not work
Fixes: #46 