### PR TITLE
Update redux to store user id on email validation

### DIFF
--- a/api/src/queries/cases.ts
+++ b/api/src/queries/cases.ts
@@ -6,7 +6,7 @@ import { Event } from '../models/Event'
 import { User } from '../models/User'
 
 // GET
-const getCases = async (req: Request, res: Response, next: NextFunction) => {
+export const getCases = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const cases = await Case.findAll()
     res.status(200).json(cases)
@@ -16,7 +16,7 @@ const getCases = async (req: Request, res: Response, next: NextFunction) => {
   }
 }
 
-const getCasesByUserId = async (req: Request, res: Response, next: NextFunction) => {
+export const getCasesByUserId = async (req: any, res: Response, next: NextFunction) => {
   const userId = parseInt(req.params.id)
   try {
     const cases = await Case.findAll({
@@ -30,7 +30,7 @@ const getCasesByUserId = async (req: Request, res: Response, next: NextFunction)
   }
 }
 
-const getCasesByCaseId = async (req: Request, res: Response, next: NextFunction) => {
+export const getCasesByCaseId = async (req: Request, res: Response, next: NextFunction) => {
   const id = parseInt(req.params.id)
   try {
     const thisCase = await Case.findByPk(id, {
@@ -65,10 +65,4 @@ const getCasesByCaseId = async (req: Request, res: Response, next: NextFunction)
     const err = { status: error.status || 500, message: error }
     next(err)
   }
-}
-
-module.exports = {
-  getCases,
-  getCasesByUserId,
-  getCasesByCaseId,
 }

--- a/api/src/queries/users.ts
+++ b/api/src/queries/users.ts
@@ -5,7 +5,7 @@ import { User } from '../models/User'
 import { sendOTPViaEmail } from '../utils/mailer'
 
 // GET
-const getUsers = async (req: Request, res: Response, next: NextFunction) => {
+export const getUsers = async (req: Request, res: Response, next: NextFunction) => {
   try {
     const users = await User.findAll()
     res.status(200).json(users)
@@ -15,7 +15,7 @@ const getUsers = async (req: Request, res: Response, next: NextFunction) => {
   }
 }
 
-const getUserById = async (req: Request, res: Response, next: NextFunction) => {
+export const getUserById = async (req: Request, res: Response, next: NextFunction) => {
   const id = parseInt(req.params.id)
   try {
     const user = await User.findOne({ where: {id} })
@@ -27,7 +27,7 @@ const getUserById = async (req: Request, res: Response, next: NextFunction) => {
 }
 
 // POST
-const createUser = async (req: Request, res: Response, next: NextFunction) => {
+export const createUser = async (req: Request, res: Response, next: NextFunction) => {
   const { name, email } = req.body
   try {
     const user = await User.create({
@@ -42,7 +42,7 @@ const createUser = async (req: Request, res: Response, next: NextFunction) => {
 }
 
 // PUT
-const updateUser = async (req: Request, res: Response, next: NextFunction) => {
+export const updateUser = async (req: Request, res: Response, next: NextFunction) => {
   const id = parseInt(req.params.id)
   const { name, email } = req.body
   try {
@@ -59,7 +59,7 @@ const updateUser = async (req: Request, res: Response, next: NextFunction) => {
 }
 
 // DELETE
-const deleteUser = async (req: Request, res: Response, next: NextFunction) => {
+export const deleteUser = async (req: Request, res: Response, next: NextFunction) => {
   const id = parseInt(req.params.id)
   try {
     await User.destroy({ where: {id} })
@@ -71,10 +71,10 @@ const deleteUser = async (req: Request, res: Response, next: NextFunction) => {
 }
 
 const genToken = (user: User) => {
-  return jwt.sign({ id: user.id }, jwtConfig.secret, { expiresIn: jwtConfig.expiry })
+  return jwt.sign({ sub: user.id }, jwtConfig.secret, { expiresIn: jwtConfig.expiry })
 }
 
-const validateEmail = async (req: any, res: Response, next: NextFunction) => {
+export const validateEmail = async (req: any, res: Response, next: NextFunction) => {
   const data = req.body
   if (!data.email) {
     const err = { status: 400, message: 'Email missing' }
@@ -98,19 +98,19 @@ const validateEmail = async (req: any, res: Response, next: NextFunction) => {
   }
 }
 
-const sendAuthEmail = async (req: any, res: Response, next: NextFunction) => {
+export const sendAuthEmail = async (req: any, res: Response, next: NextFunction) => {
   let user = req.data.user
   let token = genToken(user)
   try {
     await sendOTPViaEmail(user.email, token)
-    res.status(200).json(`Email sent`)
+    res.status(200).json({ id: user.id })
   } catch (error) {
     const err = { status: error.status || 500, message: error }
     next(err)
   }
 }
 
-const validateJWT = async (req: any, res: Response, next: NextFunction) => {
+export const validateJWT = async (req: any, res: Response, next: NextFunction) => {
   let data = req.body
   if (data.token) {
     try {
@@ -123,7 +123,7 @@ const validateJWT = async (req: any, res: Response, next: NextFunction) => {
   }
 }
 
-const setCookieWithAuthToken = async (req: any, res: Response, next: NextFunction) => {
+export const setCookieWithAuthToken = async (req: any, res: Response, next: NextFunction) => {
   let data = req.body
   try {
     if (data.token) {
@@ -144,16 +144,4 @@ const setCookieWithAuthToken = async (req: any, res: Response, next: NextFunctio
     const err = { status: error.status || 500, message: error }
     next(err)
   }
-}
-
-module.exports = {
-  getUsers,
-  getUserById,
-  createUser,
-  updateUser,
-  deleteUser,
-  validateEmail,
-  sendAuthEmail,
-  validateJWT,
-  setCookieWithAuthToken,
 }

--- a/api/src/queries/validation.ts
+++ b/api/src/queries/validation.ts
@@ -1,0 +1,10 @@
+import { Response, NextFunction } from 'express'
+
+export const validateUserId = async (req: any, res: Response, next: NextFunction) => {
+  if (parseInt(req.params.id) !== req.user.id) {
+    const err = { status: 401 }
+    next(err)
+  } else {
+    next()
+  }
+}

--- a/api/src/routes/cases.ts
+++ b/api/src/routes/cases.ts
@@ -1,15 +1,13 @@
 import express from 'express'
 import { checkSchema } from 'express-validator'
 import { getMessagesByCaseId, postMessageToCase, getEventsByCaseId, postEventToCase } from '../queries/timelines'
-
+import { getCases, getCasesByCaseId } from '../queries/cases'
 import { checkValidationPassed } from '../utils/express'
-
-const dbCases = require('../queries/cases')
 
 let router = express.Router()
 
-router.get('/', dbCases.getCases)
-router.get('/:id', dbCases.getCasesByCaseId)
+router.get('/', getCases)
+router.get('/:id', getCasesByCaseId)
 
 // TODO: add endpoints that CRUD timeline events for a given case
 

--- a/api/src/routes/users.ts
+++ b/api/src/routes/users.ts
@@ -1,25 +1,25 @@
 import express from 'express'
 import passport from 'passport'
 import jwtLogin from '../utils/passport'
+import { getCasesByUserId } from '../queries/cases'
+import { validateUserId } from '../queries/validation'
+import * as dbUsers from '../queries/users'
 
 passport.use(jwtLogin)
-const requireAuth = passport.authenticate('jwt', { session: false })
-
+let requireAuth = passport.authenticate('jwt', { session: false })
 let router = express.Router()
-const dbUsers = require('../queries/users')
-const dbCases = require('../queries/cases')
 
 router.get('/', requireAuth, dbUsers.getUsers)
 
-router.get('/:id', requireAuth, dbUsers.getUserById)
+router.get('/:id', requireAuth, validateUserId, dbUsers.getUserById)
 
 router.post('/', requireAuth, dbUsers.createUser)
 
-router.put('/:id', requireAuth, dbUsers.updateUser)
+router.put('/:id', requireAuth, validateUserId, dbUsers.updateUser)
 
 router.delete('/:id', requireAuth, dbUsers.deleteUser)
 
-router.get('/:id/cases', requireAuth, dbCases.getCasesByUserId)
+router.get('/:id/cases', requireAuth, validateUserId, getCasesByUserId)
 
 router.post('/login', dbUsers.validateEmail, dbUsers.sendAuthEmail)
 

--- a/api/src/tests/integration/routes/routes.test.ts
+++ b/api/src/tests/integration/routes/routes.test.ts
@@ -36,12 +36,13 @@ describe('route endpoints', () => {
         .post('/users/login')
         .send({ email: 'admin@opengov.com' })
         .expect(200)
-      expect(res.body).toBe('Email sent')
+      expect(res.body['id']).toBe(1)
     })
   })
 
   describe('protected routes', () => {
-    let token = jwt.sign({ id: 1 }, jwtConfig.secret, { expiresIn: jwtConfig.expiry })
+    let userId = 1 as number | any
+    let token = jwt.sign({ sub: userId }, jwtConfig.secret, { expiresIn: jwtConfig.expiry })
 
     describe('users routes', () => {
       // POST users/login/callback
@@ -66,9 +67,12 @@ describe('route endpoints', () => {
         expect(resPost.body['name']).toBe('test')
         expect(resPost.body['email']).toBe('test@user.com')
 
+        let userId = 3 as number | any
+        let token3 = jwt.sign({ sub: userId }, jwtConfig.secret, { expiresIn: jwtConfig.expiry })
+
         let resGet = await request(app)
           .get('/users/3')
-          .set('cookie', 'jwt=' + token)
+          .set('cookie', 'jwt=' + token3)
           .expect(200)
         expect(resGet.body['name']).toBe('test')
         expect(resPost.body['email']).toBe('test@user.com')
@@ -118,9 +122,9 @@ describe('route endpoints', () => {
       })
 
       // PUT users/:id
-      it('should return 200 and update email address and name of user two', async () => {
+      it('should return 200 and update email address and name of user one', async () => {
         let res = await request(app)
-          .put('/users/2')
+          .put('/users/1')
           .set('cookie', 'jwt=' + token)
           .send({
             name: 'admin3',

--- a/api/src/utils/passport.ts
+++ b/api/src/utils/passport.ts
@@ -18,7 +18,7 @@ const jwtOptions = {
 const jwtLogin = new JwtStrategy(jwtOptions, async function (payload: any, done: any) {
   try {
     const user = await User.findOne({
-      where: { id: payload.id },
+      where: { id: payload.sub },
     })
     if (user) {
       done(null, user)

--- a/client/src/components/LoginPage/index.tsx
+++ b/client/src/components/LoginPage/index.tsx
@@ -102,7 +102,7 @@ function mapStateToProps (state: any) {
   return {
     errorMessage: state.auth.errorMessage,
     authenticated: state.auth.authenticated,
-    emailValid: state.email.emailValid,
+    emailValid: state.user.emailValid,
   }
 }
 

--- a/client/src/redux/actions/index.ts
+++ b/client/src/redux/actions/index.ts
@@ -1,5 +1,6 @@
-import { AUTH_OK, AUTH_FORBIDDEN, AUTH_ERROR, API_OK, USER_LOGOUT, EMAIL_OK } from './types'
+import { AUTH_OK, AUTH_FORBIDDEN, AUTH_ERROR, API_OK, USER_LOGOUT, USER_OK } from './types'
 import { Dispatch } from 'redux'
+import { store } from '../store'
 
 export const logout = () => {
   return {
@@ -9,7 +10,7 @@ export const logout = () => {
 
 export const getCases = () => async (dispatch: Dispatch) => {
   try {
-    let id = 1
+    let id = store.getState().user.userId
     let response = await fetch(process.env.REACT_APP_API_URL + `/users/${id}/cases`, {
       method: 'GET',
       credentials: 'include',
@@ -38,8 +39,10 @@ export const validateEmailAndSendAuthToken = (props: any) => async (dispatch: Di
         email: props.email,
       }),
     })
+    let data = await response.json()
+    let id = data.id
     if (response.status === 200) {
-      dispatch({ type: EMAIL_OK, payload: true })
+      dispatch({ type: USER_OK, payload: {emailValid: true, userId: id} })
     } else {
       dispatch({ type: AUTH_FORBIDDEN, payload: 'Email not in the whitelist' })
     }
@@ -62,7 +65,7 @@ export const validateJWTAndSetCookie = (token: string) => async (dispatch: Dispa
       }),
     })
     if (response.status === 200) {
-      dispatch({ type: AUTH_OK, payload: true })
+      dispatch({ type: AUTH_OK, payload: {authenticated: true} })
     } else {
       dispatch({ type: AUTH_FORBIDDEN, payload: 'Invalid token' })
     }

--- a/client/src/redux/actions/types.ts
+++ b/client/src/redux/actions/types.ts
@@ -1,6 +1,6 @@
 export const AUTH_OK = 'AUTH_OK'
 export const AUTH_FORBIDDEN = 'AUTH_FORBIDDEN'
 export const AUTH_ERROR = 'AUTH_ERROR'
-export const EMAIL_OK = 'EMAIL_OK'
+export const USER_OK = 'USER_OK'
 export const API_OK = 'API_OK'
 export const USER_LOGOUT = 'USER_LOGOUT'

--- a/client/src/redux/reducers/index.ts
+++ b/client/src/redux/reducers/index.ts
@@ -1,10 +1,10 @@
 import { combineReducers } from 'redux'
 import auth from './auth'
 import api from './api'
-import email from './email'
+import user from './user'
 
 const appReducer = combineReducers({
-  auth, api, email,
+  auth, api, user,
 })
 
 export default appReducer

--- a/client/src/redux/reducers/user.ts
+++ b/client/src/redux/reducers/user.ts
@@ -1,13 +1,14 @@
-import { EMAIL_OK } from '../actions/types'
+import { USER_OK } from '../actions/types'
 
 const INITIAL_STATE = {
+  userId: 0,
   emailValid: false,
 }
 
 export default function (state = INITIAL_STATE, action: any) {
   switch (action.type) {
-    case EMAIL_OK:
-      return { ...state, emailValid: action.payload }
+    case USER_OK:
+      return { ...state, emailValid: action.payload.emailValid, userId: action.payload.userId }
     default:
       return state
   }


### PR DESCRIPTION
There are two design choices in this api routing case. We could either do something like `users/self/cases` as opposed to something like `users/:id/cases`. Choosing the former would invalidate the need to verify the `userId` with every api call, but its design might hinder the more general use of routes, for example in a search functionality where one would want to see some details of other cases that do not belong to them.

tldr:
using the latter api route `users/:id/cases` incurs greater implementation complexity but this is chosen for its better modularity.

- Add additional verification check for user id for routes such as `users/:id/cases` and `users/:id`
- Rename reducer from `email` to the more appropriate `user` to handle the states `emailValidated` and `userId`
- Update integration tests
Fixes: #50 